### PR TITLE
SHOWCASE-201-issuer-bug-we-need-to-creatae-a-default-issuer

### DIFF
--- a/components/onboarding-screen/basic-step-add.tsx
+++ b/components/onboarding-screen/basic-step-add.tsx
@@ -40,12 +40,11 @@ export const BasicStepAdd = () => {
   const router = useRouter();
   const { mutateAsync, isPending } = useCreateScenario();
   const currentStep = selectedStep !== null ? screens[selectedStep] : null;
-  const { showcase, setScenarioIds } = useShowcaseStore();
+  const { showcase, setScenarioIds, issuerId } = useShowcaseStore();
   const personas = showcase.personas || [];
 
   const isEditMode = stepState === "editing-basic";
   const [showErrorModal, setErrorModal] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
 
   const defaultValues = {
     title: currentStep?.title || "",
@@ -72,8 +71,6 @@ export const BasicStepAdd = () => {
   const autoSave = debounce((data: BasicStepFormData) => {
     if (!currentStep || !form.formState.isDirty) return;
 
-    setIsSaving(true);
-
     const updatedStep = {
       ...currentStep,
       title: data.title,
@@ -84,7 +81,6 @@ export const BasicStepAdd = () => {
     updateStep(selectedStep || 0, updatedStep);
 
     setTimeout(() => {
-      setIsSaving(false);
       toast.success("Changes saved", { duration: 1000 });
     }, 500);
   }, 800);
@@ -104,6 +100,7 @@ export const BasicStepAdd = () => {
     autoSave.flush();
 
     sampleScenario.personas = personas;
+    sampleScenario.issuer = issuerId;
 
     sampleScenario.steps.push({
       title: data.title,

--- a/components/onboarding-screen/basic-step-edit.tsx
+++ b/components/onboarding-screen/basic-step-edit.tsx
@@ -42,7 +42,7 @@ export const BasicStepEdit = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { mutateAsync } = useCreateScenario();
   const currentStep: any = selectedStep !== null ? screens[selectedStep] : null;
-  const { showcase, setScenarioIds } = useShowcaseStore();
+  const { showcase, setScenarioIds, issuerId } = useShowcaseStore();
   const personas = showcase.personas || [];
   const router = useRouter();
 
@@ -107,7 +107,7 @@ export const BasicStepEdit = () => {
       name: "example_name",
       description: "example_description",
       type: "ISSUANCE" as "ISSUANCE" | "PRESENTATION",
-      issuer: "3de59a17-222e-4c92-a22a-118eff7032b5",
+      issuer: issuerId,
       steps: [
         {
           title: "example_title",

--- a/hooks/use-credentials.ts
+++ b/hooks/use-credentials.ts
@@ -7,6 +7,7 @@ import {
 	IssuerResponse,
 	CredentialDefinitionsResponse,
 	CredentialSchemaRequest,
+	IssuerRequest,
 } from "@/openapi-types";
 
 const staleTime = 1000 * 60 * 5; // 5 minutes
@@ -105,8 +106,7 @@ export const useDeleteCredentialDefinition = () => {
 
 	return useMutation<void, Error, string>({
     mutationFn: async (slug: string) => {
-      const response = await apiClient.delete(`/credentials/definitions/${slug}`);
-      
+      await apiClient.delete(`/credentials/definitions/${slug}`);
     },
     onSuccess: () => {
       toast.success("Credential deleted successfully!"); 
@@ -120,5 +120,18 @@ export const useDeleteCredentialDefinition = () => {
       // Optionally refetch or reset state here
       queryClient.refetchQueries({ queryKey: ["credential"] }); // Ensure the table is refreshed
     },
+  });
+};
+
+export const useCreateIssuer = () => {
+	const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: typeof IssuerRequest._type) => {
+      const response = await apiClient.post(`/roles/issuers`, data);
+      return response;
+    },
+		onSettled: () => {
+			queryClient.invalidateQueries({ queryKey: ["issuer"] });
+		},
   });
 };

--- a/hooks/use-showcase-creation.ts
+++ b/hooks/use-showcase-creation.ts
@@ -17,7 +17,8 @@ export const useShowcaseCreation = () => {
     displayShowcase, 
     selectedPersonaIds,
     selectedCredentialDefinitionIds,
-    setScenarioIds
+    setScenarioIds,
+    issuerId
   } = useShowcaseStore();
   
   // Track scenarios being created for each persona
@@ -49,7 +50,7 @@ export const useShowcaseCreation = () => {
         ],
         personas: [persona.id],
         hidden: false,
-        issuer: "3de59a17-222e-4c92-a22a-118eff7032b5"
+        issuer: issuerId
       });
     });
     
@@ -144,7 +145,7 @@ export const useShowcaseCreation = () => {
         ],
         personas: [persona.id],
         hidden: false,
-        issuer: "3de59a17-222e-4c92-a22a-118eff7032b5"
+        issuer: issuerId
       };
       
       // Create a new map to avoid direct state mutation

--- a/hooks/use-showcases-store.ts
+++ b/hooks/use-showcases-store.ts
@@ -40,7 +40,8 @@ interface ShowcaseStore {
   // Selection states
   selectedPersonaIds: string[];
   selectedCredentialDefinitionIds: string[];
-  
+  issuerId: string;
+
   // Basic setters
   setShowcase: (showcase: ShowcaseRequestType) => void;
   setPersonaIds: (personaIds: string[]) => void;
@@ -58,6 +59,8 @@ interface ShowcaseStore {
   setSelectedCredentialDefinitionIds: (ids: string[]) => void;
   toggleSelectedCredentialDefinition: (definitionId: string) => void;
   clearSelectedCredentialDefinitions: () => void;
+
+  setIssuerId: (issuerId: string) => void;
   
   reset: () => void;
 }
@@ -103,6 +106,7 @@ const initialState = {
     }],
     personas: [],
   },
+  issuerId: "",
   selectedPersonaIds: [] as string[],
   selectedCredentialDefinitionIds: ["86a96d6d-91c9-4357-984d-1f6b162fdfae"] as string[],
 };
@@ -162,6 +166,8 @@ export const useShowcaseStore = create<ShowcaseStore>()(
       
       clearSelectedCredentialDefinitions: () => set({ selectedCredentialDefinitionIds: [] }),
       
+      setIssuerId: (issuerId: string) => set({ issuerId }),
+
       reset: () => set(initialState),
     }),
     {


### PR DESCRIPTION
- Added `useCreateIssuer` hook for managing issuer creation.
- Updated `CredentialsForm` to create an issuer alongside credential definitions.
- Modified onboarding components to utilize the new `issuerId` from the showcase store.
- Enhanced showcase creation logic to dynamically assign the issuer ID.