### PR TITLE
feat: Update persona handling in character screen

### DIFF
--- a/components/character-screen/characters.tsx
+++ b/components/character-screen/characters.tsx
@@ -153,7 +153,8 @@ export default function NewCharacterPage() {
         });
 
         toast.success("Persona has been updated.")
-
+        setStepState("no-selection");
+        setEditMode(false)
       } else {
         await createPersona(personaData, {
           onSuccess: (data: unknown) => {

--- a/hooks/use-personas.ts
+++ b/hooks/use-personas.ts
@@ -27,11 +27,15 @@ export const usePersona = (slug  : string) => {
 }
 
 export const useUpdatePersona = () => {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async ({slug,data}:{slug: string, data: typeof PersonaRequest._type}) => {
       const response = await apiClient.put(`/personas/${slug}`, data);
       return response;
     },
+    onSettled: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['personas'] });
+    }
   })
 }
 


### PR DESCRIPTION
- Added state reset after updating a persona to clear selection and exit edit mode.
- Implemented query invalidation on persona update.
- When update the persona invalidate the data.